### PR TITLE
Issue#5 roulette feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/vue-fontawesome": "^3.0.0-5",
+    "pinia": "^2.0.14",
     "vue": "^3.2.25",
     "vue-router": "^4.0.15"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vue-router": "^4.0.15"
   },
   "devDependencies": {
+    "@pinia/testing": "^0.0.12",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "@vitejs/plugin-vue": "^2.3.1",

--- a/src/components/RouletteBoard.vue
+++ b/src/components/RouletteBoard.vue
@@ -1,75 +1,80 @@
 <script setup lang="ts">
 import { useRouletteStore } from "@/store/roulette";
-
+import { ref } from "vue";
 const store = useRouletteStore();
+
+const roulette = ref<HTMLImageElement>();
+
+function rotateRoulette() {
+  const loopAnimation = [
+    { transform: "rotate(0deg)" },
+    { transform: "rotate(7200deg)" },
+  ];
+  const loopAnimationOptions = {
+    duration: 2000,
+    easing: "ease-in-out",
+  };
+  roulette.value?.animate(loopAnimation, loopAnimationOptions);
+}
+
 </script>
 
 <template>
-  <div class="relative mx-4" data-test="roulette-board">
+  <div id="roulette" ref="roulette" class="relative mx-4" data-test="roulette-board" @click="rotateRoulette">
     <img :src="store.getRouletteBoard" alt="룰렛 보드 이미지" />
     <ul>
-      <li
-        class="absolute top-20 left-32"
-        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
-      >
+      <li class="absolute top-20 left-32" :class="{ '!left-24': store.optionCurrentQuantity === 3 }">
         <label class="hidden" for="option-input-1">
           <span>룰렛옵션1</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" />
+        <input class="w-20 rounded-md border-black border-2" :class="{ 'text-center': store.optionFirstCompleted }"
+          :value="store.optionFirstText" @input="store.setFirstOption" @blur="store.addFirstOptionToList"
+          @focus="store.editFirstOption" />
       </li>
-      <li
-        class="absolute top-60 left-32"
-        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
-      >
+      <li class="absolute top-60 left-32" :class="{ '!left-24': store.optionCurrentQuantity === 3 }">
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션2</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" />
+        <input class="w-20 rounded-md border-black border-2" :class="{ 'text-center': store.optionSecondCompleted }"
+          :value="store.optionSecondText" @input="store.setSecondOption" @blur="store.addSecondOptionToList"
+          @focus="store.editSecondOption" />
       </li>
-      <li
-        class="absolute top-40 left-56 hidden"
-        :class="{ '!block': store.optionCurrentQuantity >= 3 }"
-      >
+      <li class="absolute top-40 left-56 hidden" :class="{ '!block': store.optionCurrentQuantity >= 3 }">
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션3</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" />
+        <input class="w-20 rounded-md border-black border-2" :value="store.optionThirdText"
+          @input="store.setThirdOption" @blur="store.addThridOptionToList" @focus="store.editThirdOption" />
       </li>
-      <li
-        class="absolute top-40 left-10 hidden"
-        :class="{ '!block': store.optionCurrentQuantity >= 4 }"
-      >
+      <li class="absolute top-40 left-10 hidden" :class="{ '!block': store.optionCurrentQuantity >= 4 }">
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션4</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" />
+        <input class="w-20 rounded-md border-black border-2" :value="store.optionForthText"
+          @input="store.setForthOption" @blur="store.addForthOptionToList" @focus="store.editForthOption" />
       </li>
     </ul>
   </div>
+
   <!--option controller-->
   <div class="flex justify-around my-10" data-test="option-controller">
-    <button
-      :class="{
-        'text-slate-400':
-          store.optionCurrentQuantity === store.optionMinQuantity,
-      }"
-      @click="store.changeOptionQuantity(-1)"
-    >
+    <button :class="{
+      'text-slate-400':
+        store.optionCurrentQuantity === store.optionMinQuantity,
+    }" @click="store.changeOptionQuantity(-1)">
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'minus-square']" />
     </button>
-    <button>
+    <button @click="store.clearOptionTextTotal">
       <font-awesome-icon class="w-8 h-8" :icon="['fa', 'eraser']" />
     </button>
-    <button
-      :class="{
-        'text-slate-400':
-          store.optionCurrentQuantity === store.optionMaxQuantity,
-      }"
-      @click="store.changeOptionQuantity(1)"
-    >
+    <button :class="{
+      'text-slate-400':
+        store.optionCurrentQuantity === store.optionMaxQuantity,
+    }" @click="store.changeOptionQuantity(1)">
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'plus-square']" />
     </button>
   </div>
 </template>
 
-<style></style>
+<style>
+</style>

--- a/src/components/RouletteBoard.vue
+++ b/src/components/RouletteBoard.vue
@@ -26,11 +26,16 @@ function rotateRoulette() {
     data-test="roulette-board"
     @click="rotateRoulette"
   >
-    <img :src="store.getRouletteBoard" alt="룰렛 보드 이미지" />
-    <ul>
+    <img
+      :src="store.getRouletteBoard"
+      alt="룰렛 보드 이미지"
+      data-test="roulette-image"
+    />
+    <ul data-test="roulette-option-list">
       <li
         class="absolute top-20 left-32"
         :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+        data-test="roulette-option"
       >
         <label class="hidden" for="option-input-1">
           <span>룰렛옵션1</span>
@@ -39,6 +44,7 @@ function rotateRoulette() {
           class="w-20 rounded-md border-black border-2"
           :class="{ 'text-center': store.optionFirstCompleted }"
           :value="store.optionFirstText"
+          data-test="roulette-first-option"
           @input="store.setFirstOption"
           @blur="store.addFirstOptionToList"
           @focus="store.editFirstOption"
@@ -47,6 +53,7 @@ function rotateRoulette() {
       <li
         class="absolute top-60 left-32"
         :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+        data-test="roulette-option"
       >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션2</span>
@@ -55,6 +62,7 @@ function rotateRoulette() {
           class="w-20 rounded-md border-black border-2"
           :class="{ 'text-center': store.optionSecondCompleted }"
           :value="store.optionSecondText"
+          data-test="roulette-second-option"
           @input="store.setSecondOption"
           @blur="store.addSecondOptionToList"
           @focus="store.editSecondOption"
@@ -63,6 +71,7 @@ function rotateRoulette() {
       <li
         class="absolute top-40 left-56 hidden"
         :class="{ '!block': store.optionCurrentQuantity >= 3 }"
+        data-test="roulette-option"
       >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션3</span>
@@ -70,6 +79,7 @@ function rotateRoulette() {
         <input
           class="w-20 rounded-md border-black border-2"
           :value="store.optionThirdText"
+          data-test="roulette-third-option"
           @input="store.setThirdOption"
           @blur="store.addThridOptionToList"
           @focus="store.editThirdOption"
@@ -78,6 +88,7 @@ function rotateRoulette() {
       <li
         class="absolute top-40 left-10 hidden"
         :class="{ '!block': store.optionCurrentQuantity >= 4 }"
+        data-test="roulette-option"
       >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션4</span>
@@ -85,6 +96,7 @@ function rotateRoulette() {
         <input
           class="w-20 rounded-md border-black border-2"
           :value="store.optionForthText"
+          data-test="roulette-forth-option"
           @input="store.setForthOption"
           @blur="store.addForthOptionToList"
           @focus="store.editForthOption"
@@ -94,17 +106,21 @@ function rotateRoulette() {
   </div>
 
   <!--option controller-->
-  <div class="flex justify-around my-10" data-test="option-controller">
+  <div class="flex justify-around my-10" data-test="roulette-option-counter">
     <button
       :class="{
         'text-slate-400':
           store.optionCurrentQuantity === store.optionMinQuantity,
       }"
+      data-test="roulette-change-option-decrease"
       @click="store.changeOptionQuantity(-1)"
     >
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'minus-square']" />
     </button>
-    <button @click="store.clearOptionTextTotal">
+    <button
+      data-test="roulette-option-text-reset"
+      @click="store.clearOptionTextTotal"
+    >
       <font-awesome-icon class="w-8 h-8" :icon="['fa', 'eraser']" />
     </button>
     <button
@@ -112,6 +128,7 @@ function rotateRoulette() {
         'text-slate-400':
           store.optionCurrentQuantity === store.optionMaxQuantity,
       }"
+      data-test="roulette-change-option-increase"
       @click="store.changeOptionQuantity(1)"
     >
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'plus-square']" />

--- a/src/components/RouletteBoard.vue
+++ b/src/components/RouletteBoard.vue
@@ -1,10 +1,74 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useRouletteStore } from "@/store/roulette";
+
+const store = useRouletteStore();
+</script>
 
 <template>
-  <div class="mx-4">
-    <img
-      src="https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png"
-    />
+  <div class="relative mx-4" data-test="roulette-board">
+    <img :src="store.getRouletteBoard" alt="룰렛 보드 이미지" />
+    <ul>
+      <li
+        class="absolute top-20 left-32"
+        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+      >
+        <label class="hidden" for="option-input-1">
+          <span>룰렛옵션1</span>
+        </label>
+        <input class="w-20 rounded-md border-black border-2" />
+      </li>
+      <li
+        class="absolute top-60 left-32"
+        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+      >
+        <label class="hidden" for="option-input-2">
+          <span>룰렛옵션2</span>
+        </label>
+        <input class="w-20 rounded-md border-black border-2" />
+      </li>
+      <li
+        class="absolute top-40 left-56 hidden"
+        :class="{ '!block': store.optionCurrentQuantity >= 3 }"
+      >
+        <label class="hidden" for="option-input-2">
+          <span>룰렛옵션3</span>
+        </label>
+        <input class="w-20 rounded-md border-black border-2" />
+      </li>
+      <li
+        class="absolute top-40 left-10 hidden"
+        :class="{ '!block': store.optionCurrentQuantity >= 4 }"
+      >
+        <label class="hidden" for="option-input-2">
+          <span>룰렛옵션4</span>
+        </label>
+        <input class="w-20 rounded-md border-black border-2" />
+      </li>
+    </ul>
+  </div>
+  <!--option controller-->
+  <div class="flex justify-around my-10" data-test="option-controller">
+    <button
+      :class="{
+        'text-slate-400':
+          store.optionCurrentQuantity === store.optionMinQuantity,
+      }"
+      @click="store.changeOptionQuantity(-1)"
+    >
+      <font-awesome-icon class="w-8 h-8" :icon="['far', 'minus-square']" />
+    </button>
+    <button>
+      <font-awesome-icon class="w-8 h-8" :icon="['fa', 'eraser']" />
+    </button>
+    <button
+      :class="{
+        'text-slate-400':
+          store.optionCurrentQuantity === store.optionMaxQuantity,
+      }"
+      @click="store.changeOptionQuantity(1)"
+    >
+      <font-awesome-icon class="w-8 h-8" :icon="['far', 'plus-square']" />
+    </button>
   </div>
 </template>
 

--- a/src/components/RouletteBoard.vue
+++ b/src/components/RouletteBoard.vue
@@ -16,65 +16,107 @@ function rotateRoulette() {
   };
   roulette.value?.animate(loopAnimation, loopAnimationOptions);
 }
-
 </script>
 
 <template>
-  <div id="roulette" ref="roulette" class="relative mx-4" data-test="roulette-board" @click="rotateRoulette">
+  <div
+    id="roulette"
+    ref="roulette"
+    class="relative mx-4"
+    data-test="roulette-board"
+    @click="rotateRoulette"
+  >
     <img :src="store.getRouletteBoard" alt="룰렛 보드 이미지" />
     <ul>
-      <li class="absolute top-20 left-32" :class="{ '!left-24': store.optionCurrentQuantity === 3 }">
+      <li
+        class="absolute top-20 left-32"
+        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+      >
         <label class="hidden" for="option-input-1">
           <span>룰렛옵션1</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" :class="{ 'text-center': store.optionFirstCompleted }"
-          :value="store.optionFirstText" @input="store.setFirstOption" @blur="store.addFirstOptionToList"
-          @focus="store.editFirstOption" />
+        <input
+          class="w-20 rounded-md border-black border-2"
+          :class="{ 'text-center': store.optionFirstCompleted }"
+          :value="store.optionFirstText"
+          @input="store.setFirstOption"
+          @blur="store.addFirstOptionToList"
+          @focus="store.editFirstOption"
+        />
       </li>
-      <li class="absolute top-60 left-32" :class="{ '!left-24': store.optionCurrentQuantity === 3 }">
+      <li
+        class="absolute top-60 left-32"
+        :class="{ '!left-24': store.optionCurrentQuantity === 3 }"
+      >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션2</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" :class="{ 'text-center': store.optionSecondCompleted }"
-          :value="store.optionSecondText" @input="store.setSecondOption" @blur="store.addSecondOptionToList"
-          @focus="store.editSecondOption" />
+        <input
+          class="w-20 rounded-md border-black border-2"
+          :class="{ 'text-center': store.optionSecondCompleted }"
+          :value="store.optionSecondText"
+          @input="store.setSecondOption"
+          @blur="store.addSecondOptionToList"
+          @focus="store.editSecondOption"
+        />
       </li>
-      <li class="absolute top-40 left-56 hidden" :class="{ '!block': store.optionCurrentQuantity >= 3 }">
+      <li
+        class="absolute top-40 left-56 hidden"
+        :class="{ '!block': store.optionCurrentQuantity >= 3 }"
+      >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션3</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" :value="store.optionThirdText"
-          @input="store.setThirdOption" @blur="store.addThridOptionToList" @focus="store.editThirdOption" />
+        <input
+          class="w-20 rounded-md border-black border-2"
+          :value="store.optionThirdText"
+          @input="store.setThirdOption"
+          @blur="store.addThridOptionToList"
+          @focus="store.editThirdOption"
+        />
       </li>
-      <li class="absolute top-40 left-10 hidden" :class="{ '!block': store.optionCurrentQuantity >= 4 }">
+      <li
+        class="absolute top-40 left-10 hidden"
+        :class="{ '!block': store.optionCurrentQuantity >= 4 }"
+      >
         <label class="hidden" for="option-input-2">
           <span>룰렛옵션4</span>
         </label>
-        <input class="w-20 rounded-md border-black border-2" :value="store.optionForthText"
-          @input="store.setForthOption" @blur="store.addForthOptionToList" @focus="store.editForthOption" />
+        <input
+          class="w-20 rounded-md border-black border-2"
+          :value="store.optionForthText"
+          @input="store.setForthOption"
+          @blur="store.addForthOptionToList"
+          @focus="store.editForthOption"
+        />
       </li>
     </ul>
   </div>
 
   <!--option controller-->
   <div class="flex justify-around my-10" data-test="option-controller">
-    <button :class="{
-      'text-slate-400':
-        store.optionCurrentQuantity === store.optionMinQuantity,
-    }" @click="store.changeOptionQuantity(-1)">
+    <button
+      :class="{
+        'text-slate-400':
+          store.optionCurrentQuantity === store.optionMinQuantity,
+      }"
+      @click="store.changeOptionQuantity(-1)"
+    >
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'minus-square']" />
     </button>
     <button @click="store.clearOptionTextTotal">
       <font-awesome-icon class="w-8 h-8" :icon="['fa', 'eraser']" />
     </button>
-    <button :class="{
-      'text-slate-400':
-        store.optionCurrentQuantity === store.optionMaxQuantity,
-    }" @click="store.changeOptionQuantity(1)">
+    <button
+      :class="{
+        'text-slate-400':
+          store.optionCurrentQuantity === store.optionMaxQuantity,
+      }"
+      @click="store.changeOptionQuantity(1)"
+    >
       <font-awesome-icon class="w-8 h-8" :icon="['far', 'plus-square']" />
     </button>
   </div>
 </template>
 
-<style>
-</style>
+<style></style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from "vue";
+import { createPinia } from "pinia";
 import App from "./App.vue";
 import router from "./router";
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -30,5 +31,6 @@ library.add(
 
 createApp(App)
   .use(router)
+  .use(createPinia())
   .component("font-awesome-icon", FontAwesomeIcon)
   .mount("#app");

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,4 +20,6 @@ const router = createRouter({
   routes,
 });
 
+export { routes };
+
 export default router;

--- a/src/store/roulette.ts
+++ b/src/store/roulette.ts
@@ -2,109 +2,108 @@ import { defineStore } from "pinia";
 import { Roulette } from "@/types/roulette";
 
 const optionsValidation: Roulette = {
-	minQuantity: 2,
-	maxQuantity: 4,
-	boardList: [
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle3.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle4.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle5.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle6.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle7.png",
-		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle8.png",
-	],
-	optionList: [],
-	optionFirst: "",
-	optionSecond: "",
-	optionThird: "",
-	optionForth: "",
-	optionFirstDone: false,
-	optionSecondDone: false,
-	optionThirdDone: false,
-	optionForthDone: false,
+  minQuantity: 2,
+  maxQuantity: 4,
+  boardList: [
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle3.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle4.png",
+  ],
+  optionList: [],
+  optionFirst: "",
+  optionSecond: "",
+  optionThird: "",
+  optionForth: "",
+  optionFirstDone: false,
+  optionSecondDone: false,
+  optionThirdDone: false,
+  optionForthDone: false,
 };
 
 export const useRouletteStore = defineStore("roulette", {
-	state: () => ({
-		optionCurrentQuantity: optionsValidation.minQuantity,
-		optionMinQuantity: optionsValidation.minQuantity,
-		optionMaxQuantity: optionsValidation.maxQuantity,
-		optionBoardList: optionsValidation.boardList,
-		optionTotalList: optionsValidation.optionList,
-		optionFirstText: optionsValidation.optionFirst,
-		optionSecondText: optionsValidation.optionSecond,
-		optionThirdText: optionsValidation.optionThird,
-		optionForthText: optionsValidation.optionForth,
-		optionFirstCompleted: optionsValidation.optionFirstDone,
-		optionSecondCompleted: optionsValidation.optionSecondDone,
-		optionThirdCompleted: optionsValidation.optionThirdDone,
-		optionForthCompleted: optionsValidation.optionForthDone,
-	}),
+  state: () => ({
+    optionCurrentQuantity: optionsValidation.minQuantity,
+    optionMinQuantity: optionsValidation.minQuantity,
+    optionMaxQuantity: optionsValidation.maxQuantity,
+    optionBoardList: optionsValidation.boardList,
+    optionTotalList: optionsValidation.optionList,
+    optionFirstText: optionsValidation.optionFirst,
+    optionSecondText: optionsValidation.optionSecond,
+    optionThirdText: optionsValidation.optionThird,
+    optionForthText: optionsValidation.optionForth,
+    optionFirstCompleted: optionsValidation.optionFirstDone,
+    optionSecondCompleted: optionsValidation.optionSecondDone,
+    optionThirdCompleted: optionsValidation.optionThirdDone,
+    optionForthCompleted: optionsValidation.optionForthDone,
+  }),
 
-	getters: {
-		getRouletteBoard(state): string {
-			return state.optionBoardList[
-				state.optionCurrentQuantity - state.optionMinQuantity
-			];
-		},
-	},
+  getters: {
+    getRouletteBoard(state): string {
+      return state.optionBoardList[
+        state.optionCurrentQuantity - state.optionMinQuantity
+      ];
+    },
+    getIsOptionFirstCompleted(state): boolean {
+      return state.optionFirstCompleted;
+    },
+  },
 
-	actions: {
-		changeOptionQuantity(value: number) {
-			this.optionCurrentQuantity += value;
-			if (this.optionCurrentQuantity < this.optionMinQuantity) {
-				this.optionCurrentQuantity = this.optionMinQuantity;
-			}
-			if (this.optionCurrentQuantity > this.optionMaxQuantity) {
-				this.optionCurrentQuantity = this.optionMaxQuantity;
-			}
-		},
-		setFirstOption(e: Event) {
-			this.optionFirstText = (e.target as HTMLInputElement).value;
-			this.optionTotalList.push(this.optionFirstText);
-		},
-		setSecondOption(e: Event) {
-			this.optionSecondText = (e.target as HTMLInputElement).value;
-		},
-		setThirdOption(e: Event) {
-			this.optionThirdText = (e.target as HTMLInputElement).value;
-		},
-		setForthOption(e: Event) {
-			this.optionForthText = (e.target as HTMLInputElement).value;
-		},
-		addFirstOptionToList() {
-			this.optionTotalList[0] = this.optionFirstText;
-			this.optionFirstCompleted = true;
-		},
-		addSecondOptionToList() {
-			this.optionTotalList[1] = this.optionSecondText;
-			this.optionSecondCompleted = true;
-		},
-		addThridOptionToList() {
-			this.optionTotalList[2] = this.optionThirdText;
-			this.optionThirdCompleted = true;
-		},
-		addForthOptionToList() {
-			this.optionTotalList[3] = this.optionForthText;
-			this.optionForthCompleted = true;
-		},
-		editFirstOption() {
-			this.optionFirstCompleted = false;
-		},
-		editSecondOption() {
-			this.optionSecondCompleted = false;
-		},
-		editThirdOption() {
-			this.optionThirdCompleted = false;
-		},
-		editForthOption() {
-			this.optionForthCompleted = false;
-		},
-		clearOptionTextTotal() {
-			this.optionFirstText = "";
-			this.optionSecondText = "";
-			this.optionThirdText = "";
-			this.optionForthText = "";
-		},
-	},
+  actions: {
+    changeOptionQuantity(value: number) {
+      this.optionCurrentQuantity += value;
+      if (this.optionCurrentQuantity < this.optionMinQuantity) {
+        this.optionCurrentQuantity = this.optionMinQuantity;
+      }
+      if (this.optionCurrentQuantity > this.optionMaxQuantity) {
+        this.optionCurrentQuantity = this.optionMaxQuantity;
+      }
+    },
+    setFirstOption(e: Event) {
+      this.optionFirstText = (e.target as HTMLInputElement).value;
+      this.optionTotalList.push(this.optionFirstText);
+    },
+    setSecondOption(e: Event) {
+      this.optionSecondText = (e.target as HTMLInputElement).value;
+    },
+    setThirdOption(e: Event) {
+      this.optionThirdText = (e.target as HTMLInputElement).value;
+    },
+    setForthOption(e: Event) {
+      this.optionForthText = (e.target as HTMLInputElement).value;
+    },
+    addFirstOptionToList() {
+      this.optionTotalList[0] = this.optionFirstText;
+      this.optionFirstCompleted = true;
+    },
+    addSecondOptionToList() {
+      this.optionTotalList[1] = this.optionSecondText;
+      this.optionSecondCompleted = true;
+    },
+    addThridOptionToList() {
+      this.optionTotalList[2] = this.optionThirdText;
+      this.optionThirdCompleted = true;
+    },
+    addForthOptionToList() {
+      this.optionTotalList[3] = this.optionForthText;
+      this.optionForthCompleted = true;
+    },
+    editFirstOption() {
+      this.optionFirstCompleted = false;
+    },
+    editSecondOption() {
+      this.optionSecondCompleted = false;
+    },
+    editThirdOption() {
+      this.optionThirdCompleted = false;
+    },
+    editForthOption() {
+      this.optionForthCompleted = false;
+    },
+    clearOptionTextTotal() {
+      this.optionFirstText = "";
+      this.optionSecondText = "";
+      this.optionThirdText = "";
+      this.optionForthText = "";
+    },
+  },
 });

--- a/src/store/roulette.ts
+++ b/src/store/roulette.ts
@@ -1,0 +1,45 @@
+import { defineStore } from "pinia";
+import { Roulette } from "@/types/roulette";
+
+const optionsValidation: Roulette = {
+  minQuantity: 2,
+  maxQuantity: 4,
+  boardList: [
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle3.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle4.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle5.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle6.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle7.png",
+    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle8.png",
+  ],
+};
+
+export const useRouletteStore = defineStore("roulette", {
+  state: () => ({
+    optionCurrentQuantity: optionsValidation.minQuantity,
+    optionMinQuantity: optionsValidation.minQuantity,
+    optionMaxQuantity: optionsValidation.maxQuantity,
+    optionBoardList: optionsValidation.boardList,
+  }),
+
+  getters: {
+    getRouletteBoard(state): string {
+      return state.optionBoardList[
+        state.optionCurrentQuantity - state.optionMinQuantity
+      ];
+    },
+  },
+
+  actions: {
+    changeOptionQuantity(value: number) {
+      this.optionCurrentQuantity += value;
+      if (this.optionCurrentQuantity < this.optionMinQuantity) {
+        this.optionCurrentQuantity = this.optionMinQuantity;
+      }
+      if (this.optionCurrentQuantity > this.optionMaxQuantity) {
+        this.optionCurrentQuantity = this.optionMaxQuantity;
+      }
+    },
+  },
+});

--- a/src/store/roulette.ts
+++ b/src/store/roulette.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { Roulette } from "@/types/roulette";
 
-const optionsValidation: Roulette = {
+export const roulette: Roulette = {
   minQuantity: 2,
   maxQuantity: 4,
   boardList: [
@@ -22,19 +22,19 @@ const optionsValidation: Roulette = {
 
 export const useRouletteStore = defineStore("roulette", {
   state: () => ({
-    optionCurrentQuantity: optionsValidation.minQuantity,
-    optionMinQuantity: optionsValidation.minQuantity,
-    optionMaxQuantity: optionsValidation.maxQuantity,
-    optionBoardList: optionsValidation.boardList,
-    optionTotalList: optionsValidation.optionList,
-    optionFirstText: optionsValidation.optionFirst,
-    optionSecondText: optionsValidation.optionSecond,
-    optionThirdText: optionsValidation.optionThird,
-    optionForthText: optionsValidation.optionForth,
-    optionFirstCompleted: optionsValidation.optionFirstDone,
-    optionSecondCompleted: optionsValidation.optionSecondDone,
-    optionThirdCompleted: optionsValidation.optionThirdDone,
-    optionForthCompleted: optionsValidation.optionForthDone,
+    optionCurrentQuantity: roulette.minQuantity,
+    optionMinQuantity: roulette.minQuantity,
+    optionMaxQuantity: roulette.maxQuantity,
+    optionBoardList: roulette.boardList,
+    optionTotalList: roulette.optionList,
+    optionFirstText: roulette.optionFirst,
+    optionSecondText: roulette.optionSecond,
+    optionThirdText: roulette.optionThird,
+    optionForthText: roulette.optionForth,
+    optionFirstCompleted: roulette.optionFirstDone,
+    optionSecondCompleted: roulette.optionSecondDone,
+    optionThirdCompleted: roulette.optionThirdDone,
+    optionForthCompleted: roulette.optionForthDone,
   }),
 
   getters: {

--- a/src/store/roulette.ts
+++ b/src/store/roulette.ts
@@ -2,44 +2,109 @@ import { defineStore } from "pinia";
 import { Roulette } from "@/types/roulette";
 
 const optionsValidation: Roulette = {
-  minQuantity: 2,
-  maxQuantity: 4,
-  boardList: [
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle3.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle4.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle5.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle6.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle7.png",
-    "https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle8.png",
-  ],
+	minQuantity: 2,
+	maxQuantity: 4,
+	boardList: [
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle2.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle3.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle4.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle5.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle6.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle7.png",
+		"https://ssl.pstatic.net/sstatic/keypage/outside/mobilegame/circle/im/im/bg_circle8.png",
+	],
+	optionList: [],
+	optionFirst: "",
+	optionSecond: "",
+	optionThird: "",
+	optionForth: "",
+	optionFirstDone: false,
+	optionSecondDone: false,
+	optionThirdDone: false,
+	optionForthDone: false,
 };
 
 export const useRouletteStore = defineStore("roulette", {
-  state: () => ({
-    optionCurrentQuantity: optionsValidation.minQuantity,
-    optionMinQuantity: optionsValidation.minQuantity,
-    optionMaxQuantity: optionsValidation.maxQuantity,
-    optionBoardList: optionsValidation.boardList,
-  }),
+	state: () => ({
+		optionCurrentQuantity: optionsValidation.minQuantity,
+		optionMinQuantity: optionsValidation.minQuantity,
+		optionMaxQuantity: optionsValidation.maxQuantity,
+		optionBoardList: optionsValidation.boardList,
+		optionTotalList: optionsValidation.optionList,
+		optionFirstText: optionsValidation.optionFirst,
+		optionSecondText: optionsValidation.optionSecond,
+		optionThirdText: optionsValidation.optionThird,
+		optionForthText: optionsValidation.optionForth,
+		optionFirstCompleted: optionsValidation.optionFirstDone,
+		optionSecondCompleted: optionsValidation.optionSecondDone,
+		optionThirdCompleted: optionsValidation.optionThirdDone,
+		optionForthCompleted: optionsValidation.optionForthDone,
+	}),
 
-  getters: {
-    getRouletteBoard(state): string {
-      return state.optionBoardList[
-        state.optionCurrentQuantity - state.optionMinQuantity
-      ];
-    },
-  },
+	getters: {
+		getRouletteBoard(state): string {
+			return state.optionBoardList[
+				state.optionCurrentQuantity - state.optionMinQuantity
+			];
+		},
+	},
 
-  actions: {
-    changeOptionQuantity(value: number) {
-      this.optionCurrentQuantity += value;
-      if (this.optionCurrentQuantity < this.optionMinQuantity) {
-        this.optionCurrentQuantity = this.optionMinQuantity;
-      }
-      if (this.optionCurrentQuantity > this.optionMaxQuantity) {
-        this.optionCurrentQuantity = this.optionMaxQuantity;
-      }
-    },
-  },
+	actions: {
+		changeOptionQuantity(value: number) {
+			this.optionCurrentQuantity += value;
+			if (this.optionCurrentQuantity < this.optionMinQuantity) {
+				this.optionCurrentQuantity = this.optionMinQuantity;
+			}
+			if (this.optionCurrentQuantity > this.optionMaxQuantity) {
+				this.optionCurrentQuantity = this.optionMaxQuantity;
+			}
+		},
+		setFirstOption(e: Event) {
+			this.optionFirstText = (e.target as HTMLInputElement).value;
+			this.optionTotalList.push(this.optionFirstText);
+		},
+		setSecondOption(e: Event) {
+			this.optionSecondText = (e.target as HTMLInputElement).value;
+		},
+		setThirdOption(e: Event) {
+			this.optionThirdText = (e.target as HTMLInputElement).value;
+		},
+		setForthOption(e: Event) {
+			this.optionForthText = (e.target as HTMLInputElement).value;
+		},
+		addFirstOptionToList() {
+			this.optionTotalList[0] = this.optionFirstText;
+			this.optionFirstCompleted = true;
+		},
+		addSecondOptionToList() {
+			this.optionTotalList[1] = this.optionSecondText;
+			this.optionSecondCompleted = true;
+		},
+		addThridOptionToList() {
+			this.optionTotalList[2] = this.optionThirdText;
+			this.optionThirdCompleted = true;
+		},
+		addForthOptionToList() {
+			this.optionTotalList[3] = this.optionForthText;
+			this.optionForthCompleted = true;
+		},
+		editFirstOption() {
+			this.optionFirstCompleted = false;
+		},
+		editSecondOption() {
+			this.optionSecondCompleted = false;
+		},
+		editThirdOption() {
+			this.optionThirdCompleted = false;
+		},
+		editForthOption() {
+			this.optionForthCompleted = false;
+		},
+		clearOptionTextTotal() {
+			this.optionFirstText = "";
+			this.optionSecondText = "";
+			this.optionThirdText = "";
+			this.optionForthText = "";
+		},
+	},
 });

--- a/src/test/unit/components/RouletteBoard.test.ts
+++ b/src/test/unit/components/RouletteBoard.test.ts
@@ -1,25 +1,27 @@
-import { mount } from '@vue/test-utils';
-import { createTestingPinia } from '@pinia/testing';
+import { mount } from "@vue/test-utils";
+import { createTestingPinia } from "@pinia/testing";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 
-import { faMinusSquare, faPlusSquare } from '@fortawesome/free-regular-svg-icons';
-import { faEraser } from '@fortawesome/free-solid-svg-icons';
+import {
+  faMinusSquare,
+  faPlusSquare,
+} from "@fortawesome/free-regular-svg-icons";
+import { faEraser } from "@fortawesome/free-solid-svg-icons";
 
-import RouletteBoard from '@/components/RouletteBoard.vue';
+import RouletteBoard from "@/components/RouletteBoard.vue";
 
 library.add(faMinusSquare, faPlusSquare, faEraser);
 
 describe("Test case for RouletteBoard", () => {
-	const wrapper = mount(RouletteBoard, {
-		global: {
-			plugins: [createTestingPinia()],
-			stubs: { FontAwesomeIcon }
-		}
-	})
+  const wrapper = mount(RouletteBoard, {
+    global: {
+      plugins: [createTestingPinia()],
+      stubs: { FontAwesomeIcon },
+    },
+  });
 
-	it('renders Roulette Board root element', () => {
-		expect(wrapper.find('[data-test="roulette-board"]').exists()).toBeTruthy();
-	})
-
-})
+  it("renders Roulette Board root element", () => {
+    expect(wrapper.find('[data-test="roulette-board"]').exists()).toBeTruthy();
+  });
+});

--- a/src/test/unit/components/RouletteBoard.test.ts
+++ b/src/test/unit/components/RouletteBoard.test.ts
@@ -10,10 +10,11 @@ import {
 import { faEraser } from "@fortawesome/free-solid-svg-icons";
 
 import RouletteBoard from "@/components/RouletteBoard.vue";
+import { roulette } from "@/store/roulette";
 
 library.add(faMinusSquare, faPlusSquare, faEraser);
 
-describe("Test case for RouletteBoard", () => {
+describe("Roulette Board의 element들의 존재여부를 확인합니다. ", () => {
   const wrapper = mount(RouletteBoard, {
     global: {
       plugins: [createTestingPinia()],
@@ -23,5 +24,84 @@ describe("Test case for RouletteBoard", () => {
 
   it("renders Roulette Board root element", () => {
     expect(wrapper.find('[data-test="roulette-board"]').exists()).toBeTruthy();
+  });
+
+  it("checks roulette image section exists", () => {
+    expect(wrapper.find('[data-test="roulette-image"]').exists()).toBeTruthy();
+  });
+
+  it("checks roulette option list exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-option-list"]').exists()
+    ).toBeTruthy();
+  });
+
+  it("checks option for first user choice exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-first-option"]').exists()
+    ).toBeTruthy();
+  });
+  it("checks option for second user choice exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-second-option"]').exists()
+    ).toBeTruthy();
+  });
+  it("checks option for third user choice exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-third-option"]').exists()
+    ).toBeTruthy();
+  });
+  it("checks option for forth user choice exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-forth-option"]').exists()
+    ).toBeTruthy();
+  });
+
+  it("checks option controller that changes option quantity exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-option-counter"]').exists()
+    ).toBeTruthy();
+  });
+
+  it("checks option quantity decrease button exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-change-option-decrease"]').exists()
+    ).toBeTruthy();
+  });
+
+  it("checks option quantity increase button exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-change-option-increase"]').exists()
+    ).toBeTruthy();
+  });
+
+  it("checks option text clear button exists", () => {
+    expect(
+      wrapper.find('[data-test="roulette-option-text-reset"]').exists()
+    ).toBeTruthy();
+  });
+});
+
+describe("Roulette Board의 data binding(initial state) 매칭여부를 확인합니다.", () => {
+  const initial_roulette_image: string = roulette.boardList[0];
+  const wrapper = mount(RouletteBoard, {
+    global: {
+      plugins: [createTestingPinia({})],
+      stubs: { FontAwesomeIcon },
+    },
+  });
+
+  it("checks roulette image matches with given data", () => {
+    expect(wrapper.get('[data-test="roulette-image"]').attributes("src")).toBe(
+      initial_roulette_image
+    );
+  });
+
+  it("checks display minimum quantity of option inputs on the roulette image at the point of initial rendering", () => {
+    for (let i = roulette.minQuantity; i < roulette.maxQuantity; i++) {
+      expect(
+        wrapper.findAll('[data-test="roulette-option"]')[i].classes("hidden")
+      ).toBe(true);
+    }
   });
 });

--- a/src/test/unit/components/RouletteBoard.test.ts
+++ b/src/test/unit/components/RouletteBoard.test.ts
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+
+import { faMinusSquare, faPlusSquare } from '@fortawesome/free-regular-svg-icons';
+import { faEraser } from '@fortawesome/free-solid-svg-icons';
+
+import RouletteBoard from '@/components/RouletteBoard.vue';
+
+library.add(faMinusSquare, faPlusSquare, faEraser);
+
+describe("Test case for RouletteBoard", () => {
+	const wrapper = mount(RouletteBoard, {
+		global: {
+			plugins: [createTestingPinia()],
+			stubs: { FontAwesomeIcon }
+		}
+	})
+
+	it('renders Roulette Board root element', () => {
+		expect(wrapper.find('[data-test="roulette-board"]').exists()).toBeTruthy();
+	})
+
+})

--- a/src/test/unit/views/FooterView.test.ts
+++ b/src/test/unit/views/FooterView.test.ts
@@ -1,9 +1,20 @@
 import { mount } from "@vue/test-utils";
+import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import { routes } from '@/router'
 
 import FooterView from "@/views/FooterView.vue";
 
+const router = createRouter({
+  history: createWebHistory(),
+  routes: routes
+})
+
 describe("Test case for FooterView file", () => {
-  const wrapper = mount(FooterView);
+  const wrapper = mount(FooterView, {
+    global: {
+      plugins: [router]
+    }
+  });
 
   it("renders FooterView root element", () => {
     expect(

--- a/src/test/unit/views/FooterView.test.ts
+++ b/src/test/unit/views/FooterView.test.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import { createRouter, createWebHistory } from "vue-router";
 import { routes } from '@/router'
 
 import FooterView from "@/views/FooterView.vue";

--- a/src/test/unit/views/FooterView.test.ts
+++ b/src/test/unit/views/FooterView.test.ts
@@ -1,19 +1,19 @@
 import { mount } from "@vue/test-utils";
 import { createRouter, createWebHistory } from "vue-router";
-import { routes } from '@/router'
+import { routes } from "@/router";
 
 import FooterView from "@/views/FooterView.vue";
 
 const router = createRouter({
   history: createWebHistory(),
-  routes: routes
-})
+  routes: routes,
+});
 
 describe("Test case for FooterView file", () => {
   const wrapper = mount(FooterView, {
     global: {
-      plugins: [router]
-    }
+      plugins: [router],
+    },
   });
 
   it("renders FooterView root element", () => {

--- a/src/test/unit/views/HeaderView.test.ts
+++ b/src/test/unit/views/HeaderView.test.ts
@@ -1,9 +1,20 @@
 import { mount } from "@vue/test-utils";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+
+import { faBars, faCamera, } from "@fortawesome/free-solid-svg-icons";
+import { faUser } from "@fortawesome/free-regular-svg-icons";
 
 import HeaderView from "@/views/HeaderView.vue";
 
+library.add(faBars, faCamera, faUser);
+
 describe("Test case for HeaderView file", () => {
-  const wrapper = mount(HeaderView);
+  const wrapper = mount(HeaderView, {
+    global: {
+      stubs: { FontAwesomeIcon }
+    }
+  });
 
   it("renders HeaderView root element", () => {
     expect(

--- a/src/test/unit/views/HeaderView.test.ts
+++ b/src/test/unit/views/HeaderView.test.ts
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 
-import { faBars, faCamera, } from "@fortawesome/free-solid-svg-icons";
+import { faBars, faCamera } from "@fortawesome/free-solid-svg-icons";
 import { faUser } from "@fortawesome/free-regular-svg-icons";
 
 import HeaderView from "@/views/HeaderView.vue";
@@ -12,8 +12,8 @@ library.add(faBars, faCamera, faUser);
 describe("Test case for HeaderView file", () => {
   const wrapper = mount(HeaderView, {
     global: {
-      stubs: { FontAwesomeIcon }
-    }
+      stubs: { FontAwesomeIcon },
+    },
   });
 
   it("renders HeaderView root element", () => {

--- a/src/test/unit/views/RouletteView.test.ts
+++ b/src/test/unit/views/RouletteView.test.ts
@@ -1,18 +1,25 @@
 import { mount } from "@vue/test-utils";
 import { createTestingPinia } from "@pinia/testing";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCaretDown, faEraser } from "@fortawesome/free-solid-svg-icons";
+import { faMinusSquare, faPlusSquare } from "@fortawesome/free-regular-svg-icons";
 
 import RouletterView from "@/views/RouletteView.vue";
 
-describe("Test case for RouletteView file", () => {
-  const wrapper = mount(RouletterView, {
-    global: {
-      plugins: [createTestingPinia()],
-    },
-  });
+library.add(faCaretDown, faEraser, faMinusSquare, faPlusSquare);
 
-  it("renders FooterView root element", () => {
-    expect(
-      wrapper.find('[data-test="roulette-view-root"]').exists()
-    ).toBeTruthy();
-  });
+describe("Test case for RouletteView file", () => {
+	const wrapper = mount(RouletterView, {
+		global: {
+			plugins: [createTestingPinia()],
+			stubs: { FontAwesomeIcon }
+		},
+	});
+
+	it("renders FooterView root element", () => {
+		expect(
+			wrapper.find('[data-test="roulette-view-root"]').exists()
+		).toBeTruthy();
+	});
 });

--- a/src/test/unit/views/RouletteView.test.ts
+++ b/src/test/unit/views/RouletteView.test.ts
@@ -1,13 +1,18 @@
 import { mount } from "@vue/test-utils";
+import { createTestingPinia } from '@pinia/testing';
 
 import RouletterView from "@/views/RouletteView.vue";
 
 describe("Test case for RouletteView file", () => {
-  const wrapper = mount(RouletterView);
+	const wrapper = mount(RouletterView, {
+		global: {
+			plugins: [createTestingPinia()],
+		}
+	});
 
-  it("renders FooterView root element", () => {
-    expect(
-      wrapper.find('[data-test="roulette-view-root"]').exists()
-    ).toBeTruthy();
-  });
+	it("renders FooterView root element", () => {
+		expect(
+			wrapper.find('[data-test="roulette-view-root"]').exists()
+		).toBeTruthy();
+	});
 });

--- a/src/test/unit/views/RouletteView.test.ts
+++ b/src/test/unit/views/RouletteView.test.ts
@@ -3,23 +3,26 @@ import { createTestingPinia } from "@pinia/testing";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown, faEraser } from "@fortawesome/free-solid-svg-icons";
-import { faMinusSquare, faPlusSquare } from "@fortawesome/free-regular-svg-icons";
+import {
+  faMinusSquare,
+  faPlusSquare,
+} from "@fortawesome/free-regular-svg-icons";
 
 import RouletterView from "@/views/RouletteView.vue";
 
 library.add(faCaretDown, faEraser, faMinusSquare, faPlusSquare);
 
 describe("Test case for RouletteView file", () => {
-	const wrapper = mount(RouletterView, {
-		global: {
-			plugins: [createTestingPinia()],
-			stubs: { FontAwesomeIcon }
-		},
-	});
+  const wrapper = mount(RouletterView, {
+    global: {
+      plugins: [createTestingPinia()],
+      stubs: { FontAwesomeIcon },
+    },
+  });
 
-	it("renders FooterView root element", () => {
-		expect(
-			wrapper.find('[data-test="roulette-view-root"]').exists()
-		).toBeTruthy();
-	});
+  it("renders FooterView root element", () => {
+    expect(
+      wrapper.find('[data-test="roulette-view-root"]').exists()
+    ).toBeTruthy();
+  });
 });

--- a/src/test/unit/views/RouletteView.test.ts
+++ b/src/test/unit/views/RouletteView.test.ts
@@ -1,18 +1,18 @@
 import { mount } from "@vue/test-utils";
-import { createTestingPinia } from '@pinia/testing';
+import { createTestingPinia } from "@pinia/testing";
 
 import RouletterView from "@/views/RouletteView.vue";
 
 describe("Test case for RouletteView file", () => {
-	const wrapper = mount(RouletterView, {
-		global: {
-			plugins: [createTestingPinia()],
-		}
-	});
+  const wrapper = mount(RouletterView, {
+    global: {
+      plugins: [createTestingPinia()],
+    },
+  });
 
-	it("renders FooterView root element", () => {
-		expect(
-			wrapper.find('[data-test="roulette-view-root"]').exists()
-		).toBeTruthy();
-	});
+  it("renders FooterView root element", () => {
+    expect(
+      wrapper.find('[data-test="roulette-view-root"]').exists()
+    ).toBeTruthy();
+  });
 });

--- a/src/types/roulette.ts
+++ b/src/types/roulette.ts
@@ -1,0 +1,6 @@
+export interface Roulette {
+  readonly minQuantity: number;
+  readonly maxQuantity: number;
+  readonly boardList: string[];
+  readonly inputStyleList: string[];
+}

--- a/src/types/roulette.ts
+++ b/src/types/roulette.ts
@@ -2,5 +2,13 @@ export interface Roulette {
   readonly minQuantity: number;
   readonly maxQuantity: number;
   readonly boardList: string[];
-  readonly inputStyleList: string[];
+  optionList: string[];
+  optionFirst: string;
+  optionSecond: string;
+  optionThird: string;
+  optionForth: string;
+  optionFirstDone: boolean;
+  optionSecondDone: boolean;
+  optionThirdDone: boolean;
+  optionForthDone: boolean;
 }

--- a/src/views/RouletteView.vue
+++ b/src/views/RouletteView.vue
@@ -11,12 +11,6 @@ import RouletteBoard from "@/components/RouletteBoard.vue";
       <font-awesome-icon class="w-12 h-12" :icon="['fa', 'caret-down']" />
     </div>
     <!--roulette-->
-    <RouletteBoard data-test="roulette-board" />
-    <!--option controller-->
-    <div class="flex justify-around my-10" data-test="option-controller">
-      <font-awesome-icon class="w-8 h-8" :icon="['far', 'minus-square']" />
-      <font-awesome-icon class="w-8 h-8" :icon="['fa', 'eraser']" />
-      <font-awesome-icon class="w-8 h-8" :icon="['far', 'plus-square']" />
-    </div>
+    <RouletteBoard />
   </main>
 </template>

--- a/src/views/RouletteView.vue
+++ b/src/views/RouletteView.vue
@@ -1,11 +1,26 @@
 <script setup lang="ts">
 import RouletteBoard from "@/components/RouletteBoard.vue";
+import { useRouletteStore } from "@/store/roulette";
+const store = useRouletteStore();
 </script>
 
 <template>
   <main class="flex flex-col justify-center" data-test="roulette-view-root">
     <!--result-->
-    <div class="my-4 mx-auto" data-test="option-result"></div>
+    <div class="my-4 mx-auto" data-test="option-result">
+      <span :class="{ hidden: store.optionFirstCompleted }">
+        {{ store.optionFirstText }}</span
+      >
+      <span :class="{ hidden: store.optionSecondCompleted }">{{
+        store.optionSecondText
+      }}</span>
+      <span :class="{ hidden: store.optionThirdCompleted }">{{
+        store.optionThirdText
+      }}</span>
+      <span :class="{ hidden: store.optionForthCompleted }">{{
+        store.optionForthText
+      }}</span>
+    </div>
     <!--indicator-->
     <div class="mx-auto" data-test="option-indicator">
       <font-awesome-icon class="w-12 h-12" :icon="['fa', 'caret-down']" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,14 +10,26 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "lib": ["esnext", "dom"],
+    "lib": [
+      "esnext",
+      "dom"
+    ],
     "skipLibCheck": true,
-    "types": ["vitest/globals"],
+    "types": [
+      "vitest/globals"
+    ],
     "paths": {
-      "@/*": ["./src"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.tsx",
-    "src/**/*.vue"
+    "src/**/*.vue",
   ],
   "references": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pinia/testing@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@pinia/testing/-/testing-0.0.12.tgz#1692568b4b55347429556ab43e354e81519f73e0"
+  integrity sha512-OGJ5kZihiuNua9trREAVLiv8wAlxT2+gZAz3Cen1L4ch51MbSgY5/nbo9htYsP2my9dhbggBhecgYWlhejhRcQ==
+  dependencies:
+    vue-demi "*"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@
     "@vue/compiler-dom" "3.2.33"
     "@vue/shared" "3.2.33"
 
-"@vue/devtools-api@^6.0.0":
+"@vue/devtools-api@^6.0.0", "@vue/devtools-api@^6.1.4":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.1.4.tgz#b4aec2f4b4599e11ba774a50c67fa378c9824e53"
   integrity sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==
@@ -1522,6 +1522,14 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pinia@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.14.tgz#0837898c20291ebac982bbfca95c8d3c6099925f"
+  integrity sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==
+  dependencies:
+    "@vue/devtools-api" "^6.1.4"
+    vue-demi "*"
+
 postcss-js@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"
@@ -1892,6 +1900,11 @@ vitest@^0.10.2:
     tinypool "^0.1.3"
     tinyspy "^0.3.2"
     vite "^2.9.5"
+
+vue-demi@*:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.12.5.tgz#8eeed566a7d86eb090209a11723f887d28aeb2d1"
+  integrity sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==
 
 vue-eslint-parser@^8.0.1:
   version "8.3.0"


### PR DESCRIPTION
### 아래의 요구사항을 만족하였습니다.

- [x]  사용자가 룰렛에 옵션 내용을 입력할수 있어야합니다.
    - [x]  룰렛의 각 영역에는 사용자의 input을 받을수 있는 tag가 존재합니다.
    - [x]  사용자가 작성하는 룰렛의 옵션내용은 화면 최상단(헤더영역 아래)(옵션 indicator 위)에 표시되어야합니다.
    - [x]  사용자가 작성하는 룰렛의 옵션내용을 수정할수 있어야합니다.
- [x]  사용자가 룰렛을 클릭하면 원판이 회전합니다.
    - [ ]  원판이 회전한 뒤 결과는 랜덤하게 설정되어야 합니다.
- [x]  사용자가 룰렛 하단의 옵션 증/감 버튼을 조작하여 옵션의 갯수가 변동되어야 합니다.
    - [x]  옵션에 갯수에 맞는 input form이 룰렛위에 생성되어야 합니다.
- [x]  사용자가 룰렛 하단의 옵션 지우기 버튼을 클릭하면 작성된 옵션의 TEXT가 Clear 되어야 합니다.

### 특이사항
- 룰렛의 회전을 구현하기위해 ref로 접근을 시도하였는데 이 부분을 store(pinia)에서도 관리할수 있을지 의문입니다.

### 테스트 시나리오
- [x]  존재여부 확인
    - [x]  룰렛 이미지를 보여줄 영역(element tag)이(가) 존재 합니다.
        - data-test=”roulette-image”
    - [x]  룰렛의 옵션을 입력할수 있는 영역(element tag)이(가) 존재 합니다.
        - data-test=”roulette-option-list”
    - [x]  룰렛의 첫번재 옵션을 입력할수 있는 input이 존재 합니다.
        - data-test=”roulette-first-option
    - [x]  룰렛의 두번째 옵션을 입력할수 있는 input이 존재 합니다.
        - data-test=”roulette-second-option
    - [x]  룰렛의 세번째 옵션을 입력할수 있는 input이 존재 합니다.
        - data-test=”roulette-third-option
    - [x]  룰렛의 네번재 옵션을 입력할수 있는 input이 존재 합니다.
        - data-test=”roulette-forth-option
    - [x]  룰렛의 옵션 갯수를 증/감 할수있는 영역(element tag)이(가) 존재 합니다.
        - data-test=”roulette-option-counter”
    - [x]  룰렛의 옵션을 감소 시킬수 있는 버튼이 존재합니다.
        - data-test=”roulette-change-option-decrease”
    - [x]  룰렛의 옵션을 증가 시킬수 있는 버튼이 존재합니다.
        - data-test=”roulette-change-option-increase
    - [x]  룰렛의 옵션에 입력된 text들을 초기화 시킬수 있는 버튼이 존재합니다.
        - data-test=”roulette-option-text-reset”
- [x]  Data binding 확인 여부 - initial state check
    - [x]  룰렛 보드의 이미지가 준비된 이미지를 렌더링합니다
    - [x]  룰렛의 옵션 초기 갯수는 최소값인 2개를 렌더링합니다.
        - css class 중 hidden의 항목을 확인하는 접근

### 기술부채
- [ ] 옵션의 갯수의 증/감에 따른 rotate degree에 차이를 두기
- [ ] 옵션의 갯수를 줄이면 작성하였던 옵션의 내용을 초기화 할수 있는 기능 -> 직관적인 UX제공